### PR TITLE
Fix: Attempt to resolve Angular build errors

### DIFF
--- a/src/main/webui/.gitignore
+++ b/src/main/webui/.gitignore
@@ -1,0 +1,10 @@
+# Angular
+.angular/cache
+node_modules/
+
+# Build output
+dist/
+npm-debug.log*
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+*.log
+*.tsbuildinfo

--- a/src/main/webui/package.json
+++ b/src/main/webui/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "clean": "rm -rf .angular/cache"
   },
   "private": true,
   "dependencies": {

--- a/src/main/webui/src/app/app.component.ts
+++ b/src/main/webui/src/app/app.component.ts
@@ -4,11 +4,6 @@ import { CommonModule } from '@angular/common'; // Import CommonModule
 
 @Component({
   selector: 'app-root',
-  standalone: true,
-  imports: [
-    CommonModule, // Add CommonModule here
-    RouterOutlet
-  ],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })

--- a/src/main/webui/src/app/app.module.ts
+++ b/src/main/webui/src/app/app.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { AppComponent } from './app.component';
+import { AppRoutingModule } from './app.routes';
+import { ChatComponent } from './chat/chat.component';
+import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    ChatComponent
+  ],
+  imports: [
+    BrowserModule,
+    AppRoutingModule,
+    FormsModule,
+    HttpClientModule
+  ],
+  providers: [],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }

--- a/src/main/webui/src/app/app.routes.ts
+++ b/src/main/webui/src/app/app.routes.ts
@@ -1,9 +1,16 @@
-import { Routes } from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 import { ChatComponent } from './chat/chat.component'; // Import the ChatComponent
+import { NgModule } from '@angular/core';
 
-export const appRoutes: Routes = [
+export const routes: Routes = [
   // Define your routes here later
   // Example: { path: 'dashboard', component: DashboardComponent }
   { path: 'chat', component: ChatComponent },
   { path: '', redirectTo: '/chat', pathMatch: 'full' } // Default route
 ];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule]
+})
+export class AppRoutingModule { }

--- a/src/main/webui/src/app/chat/chat.component.ts
+++ b/src/main/webui/src/app/chat/chat.component.ts
@@ -8,8 +8,6 @@ import { Chart, registerables } from 'chart.js/auto'; // Import Chart.js
 
 @Component({
   selector: 'app-chat',
-  standalone: true,
-  imports: [CommonModule, FormsModule],
   templateUrl: './chat.component.html',
   styleUrls: ['./chat.component.css']
 })

--- a/src/main/webui/src/main.ts
+++ b/src/main/webui/src/main.ts
@@ -1,12 +1,5 @@
-import { bootstrapApplication } from '@angular/platform-browser';
-import { AppComponent } from './app/app.component';
-import { provideRouter } from '@angular/router';
-import { appRoutes } from './app/app.routes'; // Will create this next
-import { provideHttpClient } from '@angular/common/http'; // Import HttpClient provider
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
 
-bootstrapApplication(AppComponent, {
-  providers: [
-    provideRouter(appRoutes),
-    provideHttpClient() // Add HttpClient provider here
-  ]
-}).catch(err => console.error(err));
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/src/main/webui/src/main/webui/package-lock.json
+++ b/src/main/webui/src/main/webui/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "webui",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This commit includes several changes aimed at fixing Angular build issues:

1.  Created `app.module.ts` to define the root `AppModule`.
2.  Updated `main.ts` to bootstrap `AppModule` instead of a standalone `AppComponent`.
3.  Modified `app.component.ts` and `chat.component.ts`:
    *   Removed `standalone: true` from their `@Component` decorators.
    *   Removed `CommonModule`, `FormsModule`, and `RouterOutlet` from their component `imports` arrays, as these should be managed by `AppModule`.
4.  Updated `app.routes.ts` to define `AppRoutingModule` which uses `RouterModule.forRoot()` and is imported into `AppModule`.
5.  Updated `app.module.ts`:
    *   Declared `AppComponent` and `ChatComponent`.
    *   Imported `BrowserModule`, `AppRoutingModule`, `FormsModule`, `HttpClientModule`.
6.  Attempted to fix a type error in `api.service.ts` in the `uploadFile` method by providing a type argument to `http.request` and casting the event.
7.  Attempted to fix a "not all code paths return a value" error in `api.service.ts` within the `sendMessage` method's promise handling.
8.  Added a `.gitignore` file to `src/main/webui` to ignore `node_modules` and `.angular/cache`.
9.  Added a `clean` script to `src/main/webui/package.json` to facilitate clearing the Angular cache.

The build process still fails with errors indicating that `AppComponent` and `ChatComponent` are being treated as standalone, and the `api.service.ts` return path error persists. I suspect a caching issue or a subtle configuration problem that I haven't been able to pinpoint yet. The next steps would involve clearing the cache and meticulously re-verifying all module and component configurations.